### PR TITLE
manage startserver.sh

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,9 @@
 ---
 driver:
   name: vagrant
+  customize:
+    memory: 1024
+    cpus: 1
 #  network:
 #    - ["forwarded_port", {guest: <port>, host: <port>}]
 provisioner:
@@ -20,3 +23,5 @@ suites:
     run_list:
       - recipe[7dtdserver::default]
     attributes:
+      7dtdserver:
+        vagrant: true

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ kitchen test
 
 ## Release History
 
+* 1.0.0
+    * first release
 * 0.1.0
     * first commit
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,40 +4,48 @@
 
 # Port you want the server to listen on.
 # Default is 26900
-default['serversettings']['serverport'] = '26900'
+default['7dtdserver']['serversettings']['serverport'] = '26900'
 
 # Should this server register to master server
 # Default is false
-default['serversettings']['serverispublic'] = 'false'
+default['7dtdserver']['serversettings']['serverispublic'] = 'false'
 
 # Whatever you want the name to be.
 # Default is My Game Host
-default['serversettings']['servername'] = 'My Game Host'
+default['7dtdserver']['serversettings']['servername'] = 'My Game Host'
 
 # Maximum Concurrent Players
 # Default is 8
-default['serversettings']['servermaxplayercount'] = '8'
+default['7dtdserver']['serversettings']['servermaxplayercount'] = '8'
 
 # Whatever you want the description to be.
 # Default is A 7 Days to Die server
-default['serversettings']['serverdescription'] = 'A 7 Days to Die server'
+default['7dtdserver']['serversettings']['serverdescription'] = 'A 7 Days to Die server'
 
 # Navezgane, MP Wasteland Horde, MP Wasteland Skirmish, MP Wasteland War, Random Gen
 # Default is Navezgane
-default['serversettings']['gameworld'] = 'Navezgane'
+default['7dtdserver']['serversettings']['gameworld'] = 'Navezgane'
 
 # Whatever you want the game name to be THIS CONTROLS THE RANDOM GENERATION SEED
 # Default is My Game
-default['serversettings']['gamename'] = 'My Game'
+default['7dtdserver']['serversettings']['gamename'] = 'My Game'
 
 # Enable/Disable the control panel
 # Default is false
-default['serversettings']['controlpanelenabled'] = 'false'
+default['7dtdserver']['serversettings']['controlpanelenabled'] = 'false'
 
 # Port of the control panel webpage
 # Default is 8080
-default['serversettings']['controlpanelport'] = '8080'
+default['7dtdserver']['serversettings']['controlpanelport'] = '8080'
 
 # Enable/Disable the telnet
 # Default is false
-default['serversettings']['telnetenabled'] = 'false'
+default['7dtdserver']['serversettings']['telnetenabled'] = 'false'
+
+#
+#    manage test flag
+#
+
+# Prevent startserver.sh from running in kitchen vagrant run
+# Defaul is false
+default['7dtdserver']['vagrant'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'alinkous+support@gmail.com'
 license 'all_rights'
 description 'Installs/Configures 7dtdserver'
 long_description 'Installs/Configures 7 Days to Die Server'
-version '0.1.0'
+version '1.0.0'
 issues_url 'https://github.com/gryte/7dtdserver/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/gryte/7dtdserver' if respond_to?(:source_url)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -75,3 +75,12 @@ template 'manage_serverconfig' do
   owner '7days'
   group '7days'
 end
+
+unless node['7dtdserver']['vagrant']
+  execute 'start_server' do
+    user '7days'
+    group '7days'
+    command 'screen -dmS 7daysded /home/7days/steamcmd/7daysded/startserver.sh -configfile=serverconfig.xml'
+    not_if 'ps cax | grep startserver.sh'
+  end
+end

--- a/templates/default/serverconfig.xml.erb
+++ b/templates/default/serverconfig.xml.erb
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 <ServerSettings>
-  <property name="ServerPort" 				value="<%= node['serversettings']['serverport'].to_s %>"/>				<!-- Port you want the server to listen on. -->
-  <property name="ServerIsPublic" 			value="<%= node['serversettings']['serverispublic'] %>"/>				<!-- Should this server register to master server -->
-  <property name="ServerName" 				value="<%= node['serversettings']['servername'] %>"/>		<!-- Whatever you want the name to be. -->
+  <property name="ServerPort" 				value="<%= node['7dtdserver']['serversettings']['serverport'].to_s %>"/>				<!-- Port you want the server to listen on. -->
+  <property name="ServerIsPublic" 			value="<%= node['7dtdserver']['serversettings']['serverispublic'] %>"/>				<!-- Should this server register to master server -->
+  <property name="ServerName" 				value="<%= node['7dtdserver']['serversettings']['servername'] %>"/>		<!-- Whatever you want the name to be. -->
   <property name="ServerPassword" 			value=""/>					<!-- Password to gain entry to the server -->
-  <property name="ServerMaxPlayerCount" 	value="<%= node['serversettings']['servermaxplayercount'].to_s %>"/>					<!-- Maximum Concurrent Players -->
-  <property name="ServerDescription" 		value="<%= node['serversettings']['serverdescription'] %>"/> <!-- Whatever you want the description to be. -->
+  <property name="ServerMaxPlayerCount" 	value="<%= node['7dtdserver']['serversettings']['servermaxplayercount'].to_s %>"/>					<!-- Maximum Concurrent Players -->
+  <property name="ServerDescription" 		value="<%= node['7dtdserver']['serversettings']['serverdescription'] %>"/> <!-- Whatever you want the description to be. -->
   <property name="ServerWebsiteURL" 		value=""/>					<!-- Website URL for the server -->
 
-  <property name="GameWorld" 				value="<%= node['serversettings']['gameworld'] %>"/>			<!-- Navezgane, MP Wasteland Horde, MP Wasteland Skirmish, MP Wasteland War, Random Gen -->
-  <property name="GameName" 				value="<%= node['serversettings']['gamename'] %>"/>			<!-- Whatever you want the game name to be THIS CONTROLS THE RANDOM GENERATION SEED -->
+  <property name="GameWorld" 				value="<%= node['7dtdserver']['serversettings']['gameworld'] %>"/>			<!-- Navezgane, MP Wasteland Horde, MP Wasteland Skirmish, MP Wasteland War, Random Gen -->
+  <property name="GameName" 				value="<%= node['7dtdserver']['serversettings']['gamename'] %>"/>			<!-- Whatever you want the game name to be THIS CONTROLS THE RANDOM GENERATION SEED -->
   <property name="GameDifficulty" 			value="2"/>  				<!-- 0 - 4, 0=easiest, 4=hardest -->
   <property name="GameMode"					value="GameModeSurvivalMP"/>	<!-- GameModeSurvivalMP, GameModeSurvivalSP (MP has land protection) -->
 
@@ -19,11 +19,11 @@
   <property name="FriendlyFire"				value="false" />			<!-- Can friendly players damage each other (PvP) -->
   <property name="PersistentPlayerProfiles"		value="true" />				<!-- If disabled a player can join with any selected profile. If true they will join with the last profile they joined with -->
 
-  <property name="ControlPanelEnabled"	 	value="<%= node['serversettings']['controlpanelenabled'] %>"/>				<!-- Enable/Disable the control panel -->
-  <property name="ControlPanelPort" 		value="<%= node['serversettings']['controlpanelport'].to_s %>"/>				<!-- Port of the control panel webpage -->
+  <property name="ControlPanelEnabled"	 	value="<%= node['7dtdserver']['serversettings']['controlpanelenabled'] %>"/>				<!-- Enable/Disable the control panel -->
+  <property name="ControlPanelPort" 		value="<%= node['7dtdserver']['serversettings']['controlpanelport'].to_s %>"/>				<!-- Port of the control panel webpage -->
   <property name="ControlPanelPassword" 	value="CHANGEME"/>			<!-- Password to gain entry to the control panel -->
 
-  <property name="TelnetEnabled"	 		value="<%= node['serversettings']['telnetenabled'] %>"/>				<!-- Enable/Disable the telnet -->
+  <property name="TelnetEnabled"	 		value="<%= node['7dtdserver']['serversettings']['telnetenabled'] %>"/>				<!-- Enable/Disable the telnet -->
   <property name="TelnetPort" 				value="8081"/>				<!-- Port of the telnet server -->
   <property name="TelnetPassword" 			value="CHANGEME"/>			<!-- Password to gain entry to telnet interface -->
 


### PR DESCRIPTION
- update attributes with parent-level index based on project name
- add attribute to control execution flow of starting server if in vagrant
- update kitchen.yml file with override attribute to not start server
- add execute resource to start server
- add inspec tests
- bump version
